### PR TITLE
Fix primary key specification when creating table

### DIFF
--- a/php/PluginToolkit.php
+++ b/php/PluginToolkit.php
@@ -42,7 +42,7 @@ abstract class PluginToolkit{
 			
 			$keys = array();
 			if(isset($primary_key)){
-				$_keys[] = "PRIMARY KEY `$primary_key`";
+				$keys[] = "PRIMARY KEY (`$primary_key`)";
 			}
 			
 			foreach(array('UNIQUE', 'INDEX', 'SPATIAL', 'FULLTEXT') as $keytype){


### PR DESCRIPTION
When activating the plugin, the `wp_nl_Languages` table could not be created. MySQL does not allow a non-key column to be `auto_increment`. It turns out that the primary key was ignored (and wasn't the right syntax either).

BTW, thanks for the plugin. I've yet to check it out completely, but it looks nice, clean and simple compared to the other multilingual plugins out there :).
