### PR TITLE
Translate based on user agent preference even if skip_default_l10n true

### DIFF
--- a/includes/class-nlingual-rewriter.php
+++ b/includes/class-nlingual-rewriter.php
@@ -174,8 +174,14 @@ final class Rewriter {
 							$the_url->meta['language'] = $language;
 							$the_url->meta['source'] = 'path';
 
-							// Update the path with the remainder
-							$the_url->path = $home_path . $matches[2];
+							// Update the path with the remainder, if any.
+							// If there's no remainder then the URL is of the form "example.com/en"
+							// with no trailing slash, so add one for consistency.
+							if(sizeof($matches) > 2) {
+								$the_url->path = $home_path . $matches[2];
+							} else {
+								$the_url->path = trailingslashit($the_url->path);
+							}
 						}
 					}
 					break;

--- a/includes/class-nlingual-system.php
+++ b/includes/class-nlingual-system.php
@@ -486,8 +486,8 @@ final class System extends Handler {
 
 			$mode = 'REQUESTED';
 		}
-		// Fallback to finding the first match in the accepted languages list, assuming skip is not enabled
-		elseif ( ! Registry::get( 'skip_default_l10n' ) && $language = self::get_accepted_language() ) {
+		// Fallback to finding the first match in the accepted languages list
+		elseif ($language = self::get_accepted_language() ) {
 			$mode = 'ACCEPTED';
 		}
 


### PR DESCRIPTION
- User agent language preferences were ignored when skip_default_l10n was true,
  unless a language was explicitly provided.

- This change causes nLingual to consider user agent language preferences even
  if skip_default_l10n is true, while still retaining standard WP URLs for
  the default language. That is, a request to "example.com" with a default
  language of "en" and a user agent preference for "fr" will redirect to
  "example.com/fr/", assuming it exists; before, it would not do this unless
  skip_default_l10n was set to false and default language requests were
  redirected to "example.com/en/", also.

- This also fixes a small redirect-loop-causing bug encountered with certain
  settings, when explicitly requesting a default language root path like
  "example.com/en" with no trailing slash.

Fixes #12